### PR TITLE
feat: 日記作成機能を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
+    "@types/google-apps-script": "^1.0.97",
     "esbuild-gas-plugin": "^0.8.0"
   }
 }

--- a/src/feature/create/index.ts
+++ b/src/feature/create/index.ts
@@ -1,0 +1,29 @@
+import { getDiaryFileName } from "../getDiaryFileName";
+
+/**
+ * 日記を作成する
+ * @param {number} offset - 現在の日付からの相対的な日数（正数：未来の日付、負数：過去の日付、0：現在の日付）
+ */
+export const createDiary = (offset: number = 0): void => {
+    const folderId = PropertiesService.getScriptProperties().getProperty("PROJECT_FOLDER_ID") || "";
+    const currentFolder = DriveApp.getFolderById(folderId);
+
+    // テンプレートファイルを取得
+    const templateFile = currentFolder.getFilesByName("日記テンプレート.md").next();
+    let templateContent = templateFile.getBlob().getDataAsString();
+    
+    // テンプレートファイルの日付をリプレイス
+    const replaceContents = {
+        '<% tp.date.now("YYYY-MM-DD", -7, tp.file.title, "YYYY-MM-DD") %>]': getDiaryFileName(-7),
+        '<% tp.date.now("YYYY-MM-DD", -1, tp.file.title, "YYYY-MM-DD") %>': getDiaryFileName(-1),
+        '<% tp.date.now("YYYY-MM-DD", 1, tp.file.title, "YYYY-MM-DD") %>': getDiaryFileName(1),
+        '<% tp.date.now("YYYY-MM-DD", 7, tp.file.title, "YYYY-MM-DD") %>': getDiaryFileName(7)
+    }
+
+    for (const [key, value] of Object.entries(replaceContents)) {
+        templateContent = templateContent.replace(key, value);
+    }
+
+    const fileName = getDiaryFileName(offset);
+    currentFolder.createFile(fileName, templateContent, "text/markdown");
+};

--- a/src/feature/file/index.ts
+++ b/src/feature/file/index.ts
@@ -1,0 +1,1 @@
+export { getDiaryFileName } from '../getDiaryFileName'; 

--- a/src/feature/file/index.ts
+++ b/src/feature/file/index.ts
@@ -1,1 +1,0 @@
-export { getDiaryFileName } from '../getDiaryFileName'; 

--- a/src/feature/getDiaryFileName.ts
+++ b/src/feature/getDiaryFileName.ts
@@ -1,0 +1,15 @@
+/**
+ * 指定された日数分前後の日付を「日記 yyyy-mm-dd.md」という形式で返す関数
+ * @param {number} offset - 現在の日付からの相対的な日数（正数：未来の日付、負数：過去の日付、0：現在の日付）
+ * @returns {string} 日記のファイル名
+ */
+export const getDiaryFileName = (offset: number = 0): string => {
+    const date = new Date();
+    date.setDate(date.getDate() + offset);
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `日記 ${year}-${month}-${day}.md`;
+}; 

--- a/src/feature/getDiaryFileName.ts
+++ b/src/feature/getDiaryFileName.ts
@@ -5,11 +5,13 @@
  */
 export const getDiaryFileName = (offset: number = 0): string => {
     const date = new Date();
-    date.setDate(date.getDate() + offset);
+    // JSTでの日付を取得
+    const jstDate = new Date(date.getTime() + (9 * 60 * 60 * 1000));
+    jstDate.setDate(jstDate.getDate() + offset);
 
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
+    const year = jstDate.getFullYear();
+    const month = String(jstDate.getMonth() + 1).padStart(2, '0');
+    const day = String(jstDate.getDate()).padStart(2, '0');
 
     return `日記 ${year}-${month}-${day}.md`;
 }; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { getDiaryFileName } from "./feature/file";
+import { createDiary } from "./feature/create";
 
-(global as any).getDiaryFileName = getDiaryFileName;
+(global as any).createDiary = createDiary;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-const main = () => {
-    console.log("Hello, World!");
-};
+import { getDiaryFileName } from "./feature/file";
+
+(global as any).getDiaryFileName = getDiaryFileName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,6 +323,11 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/google-apps-script@^1.0.97":
+  version "1.0.97"
+  resolved "https://registry.yarnpkg.com/@types/google-apps-script/-/google-apps-script-1.0.97.tgz#57c7d54785484451af2569f0b9d9bb38f3b424ff"
+  integrity sha512-T8hpQ4Yi7AUvd4fnzHfmo0joGG0j1GUC8TywvRtnKgTAv0vU/DXy4nNgw4VfcOD9ZDdJc0rGoZvWhHORipzFNQ==
+
 "@types/http-cache-semantics@*":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"


### PR DESCRIPTION
日記テンプレートからファイルを生成する createDiary 関数を追加。
インデックスファイルを更新し、グローバルスコープに関数を公開。
ファイル名生成ロジックを統合し、オフセットに基づいた日記ファイル作成を可能に。